### PR TITLE
Update to allow getting aws credentials via sts assume role

### DIFF
--- a/cmd/codecommit/main.go
+++ b/cmd/codecommit/main.go
@@ -10,8 +10,9 @@ import (
 var clobber bool
 
 const (
-	envKeyAwsProfile       = "AWS_PROFILE"
-	envKeyAwsSDKLoadConfig = "AWS_SDK_LOAD_CONFIG"
+	envKeyAwsProfile        = "AWS_PROFILE"
+	envKeyAwsSDKLoadConfig  = "AWS_SDK_LOAD_CONFIG"
+	envKeyCodeCommitRoleArn = "GO_CODECOMMIT_ROLE_ARN"
 )
 
 func setSDKLoadConfig() error {

--- a/pkg/codecommit/codecommit.go
+++ b/pkg/codecommit/codecommit.go
@@ -3,13 +3,20 @@ package codecommit
 import (
 	"fmt"
 	nurl "net/url"
+	"os"
 	"regexp"
-	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+const (
+	envKeyAwsAccessKeyID     = "AWS_ACCESS_KEY_ID"
+	envKeyAwsSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 )
 
 //
@@ -19,57 +26,43 @@ func init() {
 	RegionRe = regexp.MustCompile(`git-codecommit\.([^.]+)\.amazonaws\.com`)
 }
 
-//IsCodeCommitURL return true if the url is for a CodeCommit Git repo.
-func IsCodeCommitURL(url string) bool {
-	u, err := nurl.Parse(url)
-	if err != nil {
-		return false
-	}
-	return RegionRe.MatchString(u.Host)
+//isCodeCommitURL return true if the url is for a CodeCommit Git repo.
+func (c *CloneURL) isCodeCommitURL() bool {
+	return RegionRe.MatchString(c.u.Host)
 }
 
-//NewCloneURL return CloneURL object for CodeCommit
-func NewCloneURL(sess *session.Session, url string) (*CloneURL, error) {
-	var err error
-	if creds, err := sess.Config.Credentials.Get(); err == nil {
-		c := &CloneURL{
-			RawURL:     url,
-			CredValues: creds,
-		}
-		if err = c.setURL(); err == nil {
-			return c, nil
+//NewCloneURL return CloneURL object for CodeCommit. If the URL represents a codecommit URL, the
+//aws credentials will be set.
+func NewCloneURL(roleArn *string, rawURL string) (*CloneURL, error) {
+	url, err := nurl.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	cloneUrl := &CloneURL{
+		u: url,
+	}
+
+	if cloneUrl.isCodeCommitURL() {
+		if err := cloneUrl.setAwsCredentials(roleArn); err != nil {
+			return nil, err
 		}
 	}
-	return nil, err
+	return cloneUrl, nil
 }
 
 type CloneURL struct {
-	RawURL     string
-	CredValues credentials.Value
+	credValues credentials.Value
 	u          *nurl.URL
-}
-
-func (c *CloneURL) setURL() error {
-	u, err := nurl.Parse(c.RawURL)
-	if err != nil {
-		return err
-	}
-	c.u = u
-	return nil
 }
 
 //
 func (c *CloneURL) buildCloneURL() error {
-	err := c.setURL()
-	if err != nil {
-		return err
-	}
-	if c.u.User == nil && strings.Split(c.u.Hostname(), ".")[0] == "git-codecommit" {
-		if err = c.addCodeCommitCreds(); err != nil {
+	if c.u.User == nil && c.isCodeCommitURL() {
+		if err := c.addCodeCommitCreds(); err != nil {
 			return err
 		}
 	}
-	return err
+	return nil
 }
 
 // Include the CodeCommit HTTP AUTH params .
@@ -82,6 +75,8 @@ func (c *CloneURL) addCodeCommitCreds() error {
 	return nil
 }
 
+//String gets the url appropriate for cloning. If the the URL is a codecommit URL, the username and
+//password will be added to the url.
 func (c *CloneURL) String() string {
 	err := c.buildCloneURL()
 	if err != nil {
@@ -97,10 +92,10 @@ func (c *CloneURL) GetCodeCommitCredentials() (*CodeCommitCredentials, error) {
 		return nil, err
 	}
 
-	ctx := NewSigningContext(c.u, region, endpoints.CodecommitServiceID, c.CredValues, time.Now())
-	username := c.CredValues.AccessKeyID
-	if c.CredValues.SessionToken != "" {
-		username = fmt.Sprintf("%s%%%s", username, c.CredValues.SessionToken)
+	ctx := NewSigningContext(c.u, region, endpoints.CodecommitServiceID, c.credValues, time.Now())
+	username := c.credValues.AccessKeyID
+	if c.credValues.SessionToken != "" {
+		username = fmt.Sprintf("%s%%%s", username, c.credValues.SessionToken)
 	}
 
 	return &CodeCommitCredentials{
@@ -120,6 +115,48 @@ func (c *CloneURL) parseRegion() (string, error) {
 	}
 
 	return "", fmt.Errorf("invalid CodeCommit URL %q", c.u.String())
+}
+
+func (c *CloneURL) setAwsCredentials(roleArn *string) error {
+	var creds credentials.Value
+	if roleArn != nil {
+		if err := validateAssumeRoleConfig(); err != nil {
+			return err
+		}
+		region, err := c.parseRegion()
+		if err != nil {
+			return err
+		}
+
+		cfg := &aws.Config{
+			Region: &region,
+		}
+		sess := session.Must(session.NewSession(cfg))
+		if creds, err = stscreds.NewCredentials(sess, *roleArn).Get(); err != nil {
+			return err
+		}
+	} else {
+		// Get the creds without sts assume role. AWS_PROFILE and AWS_SDK_LOAD_CONFIG must be set.
+		sess, err := session.NewSession()
+		if err != nil {
+			return err
+		}
+		if creds, err = sess.Config.Credentials.Get(); err != nil {
+			return err
+		}
+	}
+	c.credValues = creds
+	return nil
+}
+
+func validateAssumeRoleConfig() error {
+	if _, isset := os.LookupEnv(envKeyAwsAccessKeyID); !isset {
+		return fmt.Errorf("cannot assume role since the env var: '%s' must be set", envKeyAwsAccessKeyID)
+	}
+	if _, isset := os.LookupEnv(envKeyAwsSecretAccessKey); !isset {
+		return fmt.Errorf("cannot assume role since the env var: '%s' must be set", envKeyAwsSecretAccessKey)
+	}
+	return nil
 }
 
 type CodeCommitCredentials struct {

--- a/pkg/codecommit/codecommit_test.go
+++ b/pkg/codecommit/codecommit_test.go
@@ -43,10 +43,7 @@ type CloneURLTest struct {
 
 func (e *CloneURLTest) assertInvalidRegion() {
 	t := e.t
-	c := CloneURL{
-		RawURL: e.topts.uRL,
-	}
-	err := c.setURL()
+	c, err := NewCloneURL(nil, e.topts.uRL)
 	if err != nil {
 		t.Error(err)
 	}
@@ -59,10 +56,10 @@ func (e *CloneURLTest) assertInvalidRegion() {
 
 func (e *CloneURLTest) assertRegion() {
 	t := e.t
-	c := CloneURL{
-		RawURL: e.topts.uRL,
+	c, err := NewCloneURL(nil, e.topts.uRL)
+	if err != nil {
+		t.Error(err)
 	}
-	err := c.setURL()
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/codecommit/git.go
+++ b/pkg/codecommit/git.go
@@ -18,11 +18,11 @@ type RepoWrapper struct {
 }
 
 //Clone a Git repo, return true if the repo is up to date or was from an empty clone.
-func (r *RepoWrapper) Clone(cloneURL string, destDir string) (*git.Repository, bool, error) {
+func (r *RepoWrapper) Clone(cloneURL *CloneURL, destDir string) (*git.Repository, bool, error) {
 	log.Debugf("Cloning Git repo %s, dest %s", cloneURL, destDir)
 
 	cloneOpts := &git.CloneOptions{
-		URL: cloneURL,
+		URL: cloneURL.String(),
 	}
 
 	repo, err := git.PlainClone(destDir, false, cloneOpts)

--- a/pkg/codecommit/git_test.go
+++ b/pkg/codecommit/git_test.go
@@ -21,7 +21,11 @@ func TestRepoWrapperCloneEmpty(t *testing.T) {
 
 	repoWrapper := RepoWrapper{}
 	destDir := filepath.Join(repoRoot, "dest")
-	r, isEmpty, err := repoWrapper.Clone(repoRoot, destDir)
+	cloneUrl, err := NewCloneURL(nil, repoRoot)
+	if err != nil {
+		t.Fatalf("Failed to create clone url for repo %v, err=%v", repoRoot, err)
+	}
+	r, isEmpty, err := repoWrapper.Clone(cloneUrl, destDir)
 	if err != nil {
 		t.Fatalf("Failed cloning repo %v, err=%v, repo=%v", repoRoot, err, r)
 
@@ -61,10 +65,13 @@ func TestRepoWrapperClone(t *testing.T) {
 
 	repoWrapper := RepoWrapper{}
 	destDir := filepath.Join(repoRoot, "dest")
-	r, isEmpty, err := repoWrapper.Clone(repoRoot, destDir)
+	cloneUrl, err := NewCloneURL(nil, repoRoot)
+	if err != nil {
+		t.Fatalf("Failed to create clone url for repo %v, err=%v", repoRoot, err)
+	}
+	r, isEmpty, err := repoWrapper.Clone(cloneUrl, destDir)
 	if err != nil {
 		t.Fatalf("Failed cloning repo %v, err=%v, repo=%v", repoRoot, err, r)
-
 	}
 	if isEmpty {
 		t.Fatalf("Repo %v should not have been empty", repoRoot)


### PR DESCRIPTION
This pull request addresses issue #6 by adding support for using STS Assume Role when generating codecommit credentials.


The commands have been updated as follows:

**credential-helper**
- Added support for configuring the role arn by environment variable: GO_CODECOMMIT_ASSUME_ROLE
- Added support for configuring the AWS credentials via the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

**credential**
- Added support for configuring the role arn by environment variable: GO_CODECOMMIT_ASSUME_ROLE or by command line flag --role-arn
- Added support for AWS credentials via the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

