### PR TITLE
Added support for getting aws credentials via sts assume role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,19 @@ jobs:
       - run: curl -f --location https://releases.hashicorp.com/terraform/0.12.27/terraform_0.12.27_linux_amd64.zip -o /tmp/terraform.zip && unzip -o /tmp/terraform.zip -d $GOPATH/bin
       - run: make build
       - run: make test
+
+  publish:
+    branches:
+      only:
+        - master
+
+    docker:
+      - image: circleci/golang:1.14
+
+    working_directory: /go/src/github.com/bashims/go-codecommit
+
+    steps:
+      - checkout
       - run: |
           echo "$DOCKER_PASS" | docker login -u $DOCKER_USER --password-stdin
           make build-docker push-docker

--- a/cmd/codecommit/credentials.go
+++ b/cmd/codecommit/credentials.go
@@ -8,14 +8,22 @@ import (
 	"regexp"
 	"text/template"
 
+	"github.com/aws/aws-sdk-go/aws"
+	stscreds "github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/bashims/go-codecommit/pkg/codecommit"
 	"github.com/spf13/cobra"
+
+	"github.com/bashims/go-codecommit/pkg/codecommit"
 )
 
 const (
 	envKeyCodeCommitURL = "CODECOMMIT_URL"
-	helperTemplate      = `username={{ .Credentials.Username }}
+
+	envKeyAwsAccessKeyID     = "AWS_ACCESS_KEY_ID"
+	envKeyAwsSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+	envKeyCodeCommitRoleArn  = "GO_CODECOMMIT_ROLE_ARN"
+
+	helperTemplate = `username={{ .Credentials.Username }}
 password={{ .Credentials.Password }}
 `
 	gitCredentialsHelperAPIDoc = "https://git-scm.com/docs/api-credentials#_credential_helpers"
@@ -44,8 +52,10 @@ type Values struct {
 }
 
 type CodeCommitCredentials struct {
-	sess   *session.Session
-	method string
+	sess    *session.Session
+	roleArn *string
+	region  *string
+	method  string
 }
 
 func (c *CodeCommitCredentials) parseGitInput() GitRequest {
@@ -117,13 +127,33 @@ func (c *CodeCommitCredentials) emitCreds(url, format string) error {
 //session getter/setter returns *session.session
 func (c *CodeCommitCredentials) session() (*session.Session, error) {
 	if c.sess == nil {
-		sess, err := session.NewSession()
+		cfg := &aws.Config{
+			Region: c.region,
+		}
+		sess, err := session.NewSession(cfg)
 		if err != nil {
 			return nil, err
+		}
+
+		if c.roleArn != nil {
+			if err := validateAssumeRoleConfig(); err != nil {
+				return nil, err
+			}
+			sess.Config.Credentials = stscreds.NewCredentials(sess, *c.roleArn)
 		}
 		c.sess = sess
 	}
 	return c.sess, nil
+}
+
+func validateAssumeRoleConfig() error {
+	if _, isset := os.LookupEnv(envKeyAwsAccessKeyID); !isset {
+		return fmt.Errorf("cannot assume role since the env var: '%s' must be set", envKeyAwsAccessKeyID)
+	}
+	if _, isset := os.LookupEnv(envKeyAwsSecretAccessKey); !isset {
+		return fmt.Errorf("cannot assume role since the env var: '%s' must be set", envKeyAwsSecretAccessKey)
+	}
+	return nil
 }
 
 func (c *CodeCommitCredentials) execute(cmd *cobra.Command, args []string) error {
@@ -145,11 +175,42 @@ func (c *CodeCommitCredentials) execute(cmd *cobra.Command, args []string) error
 		format = helperTemplate
 	}
 
+	roleArn, err := f.GetString("role-arn")
+	if err != nil {
+		return err
+	}
+	if roleArn == "" {
+		if r, isset := os.LookupEnv(envKeyCodeCommitRoleArn); isset {
+			roleArn = r
+		}
+	}
+	if roleArn != "" {
+		c.roleArn = &roleArn
+	}
+	region, err := codecommit.ParseRegion(url)
+	if err != nil {
+		return err
+	}
+	c.region = &region
+
 	return c.emitCreds(url, format)
 }
 
 func (c *CodeCommitCredentials) executeCredentialHelper(cmd *cobra.Command, args []string) error {
 	r := c.parseGitInput()
+
+	if codecommit.IsCodeCommitURL(r.url()) {
+		if r, isset := os.LookupEnv(envKeyCodeCommitRoleArn); isset {
+		    c.roleArn = &r
+	    }
+	
+		region, err := codecommit.ParseRegion(r.host)
+		if err != nil {
+			return err
+		}
+		c.region = &region
+	}
+
 	return c.emitCreds(r.url(), helperTemplate)
 }
 
@@ -177,6 +238,7 @@ codecommit credential --url https://git-codecommit.us-east-1.amazonaws.com/v1/re
 		fmt.Sprintf("emit credentials for URL\nCan be set from the environment with %s",
 			envKeyCodeCommitURL))
 	cmd.Flags().String("template", "", "template output (Go templating)")
+	cmd.Flags().String("role-arn", "", "role to assume when retrieving aws credentials, requires 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_KEY_ID' env vars to be set")
 	return cmd
 }
 

--- a/cmd/codecommit/git.go
+++ b/cmd/codecommit/git.go
@@ -80,10 +80,8 @@ func (g *GitCmd) clone(args []string, flags *pflag.FlagSet) error {
 		if err != nil {
 			return err
 		}
-		if roleArn == "" {
-			if r, isset := os.LookupEnv(envKeyCodeCommitRoleArn); isset {
-				roleArn = r
-			}
+		if roleArn != "" && os.Getenv(envKeyAwsProfile) != "" {
+			return fmt.Errorf("only one of role arn or profile should be set")
 		}
 		if roleArn != "" {
 			g.roleArn = &roleArn
@@ -165,7 +163,7 @@ codecommit clone https://git-codecommit.us-east-1.amazonaws.com/v1/repos/your-re
 		Args: cobra.MaximumNArgs(2),
 	}
 
-	cmd.Flags().String("role-arn", "", "role to assume when retrieving aws credentials, requires 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_KEY_ID' env vars to be set")
+	cmd.Flags().String("role-arn", os.Getenv(envKeyCodeCommitRoleArn), "role to assume when retrieving aws credentials, requires 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_KEY_ID' env vars to be set")
 	return cmd
 }
 

--- a/cmd/codecommit/git.go
+++ b/cmd/codecommit/git.go
@@ -6,21 +6,27 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/bashims/go-codecommit/pkg/codecommit"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/bashims/go-codecommit/pkg/codecommit"
 )
 
 //GitCmd for commandline execution
 type GitCmd struct {
 	wrapper codecommit.RepoWrapper
 	sess    *session.Session
+	region  *string
+	roleArn *string
 }
 
 func (g *GitCmd) execute(cmd *cobra.Command, args []string) error {
 	switch command := cmd.Name(); command {
 	case "clone":
-		return g.clone(args)
+		return g.clone(args, cmd.Flags())
 	case "pull":
 		return g.pull(args)
 	case "push":
@@ -60,7 +66,7 @@ func (g *GitCmd) push(args []string) error {
 	return err
 }
 
-func (g *GitCmd) clone(args []string) error {
+func (g *GitCmd) clone(args []string, flags *pflag.FlagSet) error {
 	url := os.Getenv(envKeyCodeCommitURL)
 	if url == "" {
 		if len(args) < 1 {
@@ -70,6 +76,22 @@ func (g *GitCmd) clone(args []string) error {
 	}
 
 	if codecommit.IsCodeCommitURL(url) {
+		roleArn, err := flags.GetString("role-arn")
+		if err != nil {
+			return err
+		}
+		if roleArn == "" {
+			if r, isset := os.LookupEnv(envKeyCodeCommitRoleArn); isset {
+				roleArn = r
+			}
+		}
+		if roleArn != "" {
+			g.roleArn = &roleArn
+		}
+
+		region, err := codecommit.ParseRegion(url)
+		g.region = &region
+
 		sess, err := g.session()
 		if err != nil {
 			return err
@@ -107,9 +129,19 @@ func (g *GitCmd) clone(args []string) error {
 //session getter/setter returns *session.session
 func (g *GitCmd) session() (*session.Session, error) {
 	if g.sess == nil {
-		sess, err := session.NewSession()
+		cfg := &aws.Config{
+			Region: g.region,
+		}
+		sess, err := session.NewSession(cfg)
 		if err != nil {
 			return nil, err
+		}
+
+		if g.roleArn != nil {
+			if err := validateAssumeRoleConfig(); err != nil {
+				return nil, err
+			}
+			sess.Config.Credentials = stscreds.NewCredentials(sess, *g.roleArn)
 		}
 		g.sess = sess
 	}
@@ -132,6 +164,8 @@ codecommit clone https://git-codecommit.us-east-1.amazonaws.com/v1/repos/your-re
 		RunE: c.execute,
 		Args: cobra.MaximumNArgs(2),
 	}
+
+	cmd.Flags().String("role-arn", "", "role to assume when retrieving aws credentials, requires 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_KEY_ID' env vars to be set")
 	return cmd
 }
 

--- a/cmd/codecommit/git.go
+++ b/cmd/codecommit/git.go
@@ -20,7 +20,7 @@ type GitCmd struct {
 	wrapper codecommit.RepoWrapper
 	sess    *session.Session
 	region  *string
-	roleArn *string
+	roleARN *string
 }
 
 func (g *GitCmd) execute(cmd *cobra.Command, args []string) error {
@@ -76,15 +76,15 @@ func (g *GitCmd) clone(args []string, flags *pflag.FlagSet) error {
 	}
 
 	if codecommit.IsCodeCommitURL(url) {
-		roleArn, err := flags.GetString("role-arn")
+		roleARN, err := flags.GetString("role-arn")
 		if err != nil {
 			return err
 		}
-		if roleArn != "" && os.Getenv(envKeyAwsProfile) != "" {
+		if roleARN != "" && os.Getenv(envKeyAwsProfile) != "" {
 			return fmt.Errorf("only one of role arn or profile should be set")
 		}
-		if roleArn != "" {
-			g.roleArn = &roleArn
+		if roleARN != "" {
+			g.roleARN = &roleARN
 		}
 
 		region, err := codecommit.ParseRegion(url)
@@ -135,11 +135,8 @@ func (g *GitCmd) session() (*session.Session, error) {
 			return nil, err
 		}
 
-		if g.roleArn != nil {
-			if err := validateAssumeRoleConfig(); err != nil {
-				return nil, err
-			}
-			sess.Config.Credentials = stscreds.NewCredentials(sess, *g.roleArn)
+		if g.roleARN != nil {
+			sess.Config.Credentials = stscreds.NewCredentials(sess, *g.roleARN)
 		}
 		g.sess = sess
 	}
@@ -163,7 +160,7 @@ codecommit clone https://git-codecommit.us-east-1.amazonaws.com/v1/repos/your-re
 		Args: cobra.MaximumNArgs(2),
 	}
 
-	cmd.Flags().String("role-arn", os.Getenv(envKeyCodeCommitRoleArn), "role to assume when retrieving aws credentials, requires 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_KEY_ID' env vars to be set")
+	cmd.Flags().String("role-arn", os.Getenv(envKeyCodeCommitRoleARN), "role to assume when retrieving aws credentials, requires 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_KEY_ID' env vars to be set")
 	return cmd
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/magiconair/properties v1.8.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag v1.0.5
 	github.com/xanzy/ssh-agent v0.2.1 // indirect
 	gopkg.in/src-d/go-billy.v4 v4.3.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.10.0

--- a/pkg/codecommit/codecommit.go
+++ b/pkg/codecommit/codecommit.go
@@ -126,7 +126,7 @@ func ParseRegion(host string) (string, error) {
 		return match[1], nil
 	}
 
-	return "", fmt.Errorf("invalid CodeCommit host %q", host)
+	return "", fmt.Errorf("invalid CodeCommit URL %q", host)
 }
 
 type CodeCommitCredentials struct {


### PR DESCRIPTION
This pull request addresses issue #6 by adding support for using STS Assume Role when generating codecommit credentials.

The commands have been updated as follows:

**credential-helper**

- Added support for configuring the role arn by environment variable: GO_CODECOMMIT_ASSUME_ROLE
- Added support for configuring the AWS credentials via the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

**credential**
- Added support for configuring the role arn by environment variable: GO_CODECOMMIT_ASSUME_ROLE or by command line flag --role-arn
- Added support for AWS credentials via the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

**clone**
- Added support for configuring the role arn by environment variable: GO_CODECOMMIT_ASSUME_ROLE or by command line flag --role-arn
- Added support for AWS credentials via the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
